### PR TITLE
Term::ReadLine::Gnu 1.44 release.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 -*- Indented-text -*-
 
+1.44  2022-11-06
+	- change the TERM check as bash does (#11)
+	    - Use `Term::ReadLine::Stub` if the environment variable `TERM` is
+	      set to `"emacs"` or the environment variable `INSIDE_EMACS` or
+	      `EMACS` is defined.
+
 1.43  2022-09-27
 	- readline-8.2 support
 	    new functions

--- a/Gnu.pm
+++ b/Gnu.pm
@@ -78,12 +78,17 @@ the Term::ReadLine documentation for more information.
 END
     }
 }
-# use Term::ReadLine::Stub on a dumb terminal.
-# https://rt.cpan.org/Ticket/Display.html?id=123398
-# Debian Bug Report #99843
+
 BEGIN {
-    if (!exists($ENV{TERM}) || !defined($ENV{TERM}) || $ENV{TERM} =~ /^(dumb|emacs|unknown|)$/) {
-        croak "dumb terminal.";
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=99843
+    $ENV{TERM} = 'dumb' unless defined($ENV{TERM});
+
+    # Use Term::ReadLine::Stub in Emacs
+    # as bash does not do line-editing in the case. (cf. bash-5.2/shell.c)
+    # https://rt.cpan.org/Ticket/Display.html?id=123398
+    # https://github.com/hirooih/perl-trg/issues/11
+    if ($ENV{TERM} eq "emacs" || defined($ENV{EMACS}) || defined($ENV{INSIDE_EMACS})) {
+        croak "Use Term::ReadLine::Stub.";
     }
 }
 
@@ -2176,6 +2181,10 @@ The environment variable C<PERL_RL> governs which ReadLine clone is
 loaded.  See the ENVIRONMENT section on
 L<Term::ReadLine|http://search.cpan.org/dist/Term-ReadLine/> for
 further details.
+
+If the environment variable C<TERM> is set to C<"emacs">
+or the environment variable C<INSIDE_EMACS> or C<EMACS> is defined,
+C<Term::ReadLine::Stub> is used instead of <Term::ReadLine:Gnu>.
 
 =head1 SEE ALSO
 

--- a/Gnu.pm
+++ b/Gnu.pm
@@ -1,7 +1,7 @@
 #
 #       Gnu.pm --- The GNU Readline/History Library wrapper module
 #
-#       Copyright (c) 1996-2021 Hiroo Hayashi.  All rights reserved.
+#       Copyright (c) 1996-2022 Hiroo Hayashi.  All rights reserved.
 #
 #       This program is free software; you can redistribute it and/or
 #       modify it under the same terms as Perl itself.
@@ -96,7 +96,7 @@ BEGIN {
     use Exporter ();
     use DynaLoader;
 
-    our $VERSION = '1.43';              # update Gnu::XS::VERSION also.
+    our $VERSION = '1.44';              # update Gnu::XS::VERSION also.
 
     # Term::ReadLine::Gnu::AU makes a function in
     # `Term::ReadLine::Gnu::XS' as a method.

--- a/Gnu/XS.pm
+++ b/Gnu/XS.pm
@@ -1,7 +1,7 @@
 #
 #       XS.pm : perl function definition for Term::ReadLine::Gnu
 #
-#       Copyright (c) 1999-2021 Hiroo Hayashi.  All rights reserved.
+#       Copyright (c) 1999-2022 Hiroo Hayashi.  All rights reserved.
 #
 #       This program is free software; you can redistribute it and/or
 #       modify it under the same terms as Perl itself.
@@ -14,7 +14,7 @@ use warnings;
 use AutoLoader 'AUTOLOAD';
 
 our $VERSION;
-$VERSION='1.43';        # added for CPAN
+$VERSION='1.44';        # added for CPAN
 
 # make aliases
 our %Attribs;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,12 +30,6 @@ if ($ENV{AUTOMATED_TESTING} && !open(SESAMI, '/dev/tty')) {
     warn "cannot open /dev/tty\n";
     exit 0;
 }
-# https://rt.cpan.org/Ticket/Display.html?id=128806
-# https://github.com/hirooih/perl-trg/issues/11
-if (!exists($ENV{TERM}) || !defined($ENV{TERM}) || $ENV{TERM} =~ /^(dumb|emacs|unknown|)$/) {
-    warn "Warning: wrong \$TERM value, '$ENV{TERM}'. The GNU Readline Library does not work properly.\n";
-    exit 0 if $ENV{AUTOMATED_TESTING};  # exit on CPAN testers
-}
 
 push(@defs, '-DHAVE_STRING_H') if ($Config{strings} =~ m|/string.h$|);
 

--- a/t/00checkver.t
+++ b/t/00checkver.t
@@ -27,8 +27,8 @@ $loaded = 1;
 
 # The GNU Readline library requires $TERM to be set properly.
 # https://github.com/hirooih/perl-trg/issues/11
-if (!exists($ENV{TERM}) || !defined($ENV{TERM}) || $ENV{TERM} =~ /^(dumb|emacs|unknown|)$/) {
-    warn "wrong \$TERM value: $ENV{TERM}\n";
+if ($ENV{TERM} eq "emacs" || defined($ENV{EMACS}) || defined($ENV{INSIDE_EMACS})) {
+    warn "Wrong env setting: \$TERM is set to 'emacs', or \$EMACS or \$INSIDE_EMACS is defined.\n";
     exit 1;
 }
 ok(1, '$TERM value');


### PR DESCRIPTION
change the TERM check as bash does (#11)
    
Use `Term::ReadLine::Stub` if the environment variable `TERM` is set to `"emacs"` or the environment variable `INSIDE_EMACS` or `EMACS` is defined.