### PR TITLE
Reproduce Term::ReadLine::Stub’s behavior for ornaments

### DIFF
--- a/Gnu/XS.pm
+++ b/Gnu/XS.pm
@@ -46,7 +46,8 @@ rl_add_defun('change-ornaments',         \&change_ornaments);
 # Prompt-start, prompt-end, command-line-start, command-line-end
 #     -- zero-width beautifies to emit around prompt and the command line.
 # string encoded:
-my $rl_term_set = ',,,';
+our @rl_term_set;
+*rl_term_set = \@Term::ReadLine::TermCap::rl_term_set;
 
 # These variables are used by completion functions.  Don't use for
 # other purpose.
@@ -361,12 +362,12 @@ our %term_no_ue = ( kterm => 1 );
 
 sub ornaments {
     return $rl_term_set unless @_;
-    $rl_term_set = shift;
+    my $rl_term_set = shift;
     $rl_term_set ||= ',,,';
-    $rl_term_set = $term_no_ue{$ENV{TERM}} ? 'us,me,,' : 'us,ue,,'
+    $rl_term_set = $term_no_ue{$ENV{TERM}} ? 'us,me,md,me' : 'us,ue,md,me'
         if $rl_term_set eq '1';
     my @ts = split /,/, $rl_term_set, 4;
-    my @rl_term_set
+    @rl_term_set
         = map {
             # non-printing characters must be informed to readline
             my $t;


### PR DESCRIPTION
The Perl debugger invoked by `perl -d` relies on @<!---->Term::ReadLine::TermCap::rl_term_set for control sequences to format its online help for display. Contrary to what the documentation suggests, in the absence of /etc/termcap, which is always the case on modern GNU/Linux systems, Term::Cap 'falls back' to terminfo by invoking infocmp. Thus, Term::ReadLine::Gnu obtains the exact same information, but only exports it through its own %Attribs variable, unbeknownst to the debugger.

It would be possible to simply inherit from Term::ReadLine::TermCap, but the current implementation, which doesn't chase after obsolete files or spawn an independent process, ought to be far more efficient.

Another incompatibility is that Term::ReadLine::Gnu doesn't fetch the control sequences for outputting bold text. I don't see any good reason for that. They should be exported as well in order to allow the debugger to utilize full formatting.

(By contrast, the fact that this package doesn't follow the stub implementation in attempting to decorate the *input line* with bold is commendable. Since there is no attempt to save and restore terminal state on SIGTSTP, the stub implementation plays poorly with job control, which is entirely unacceptable behavior for a UNIX program.)