### PR TITLE
import examples from the GNU Readline Library

### DIFF
--- a/Gnu.pm
+++ b/Gnu.pm
@@ -1331,6 +1331,18 @@ Manual|https://tiswww.cwru.edu/php/chet/readline/readline.html>.
 
 =over 4
 
+=item C<SETSTATE(READLINE_STATE)>
+
+        int  RL_SETSTATE(int)                                   # GRL 6.0
+
+=item C<UNSETSTATE(READLINE_STATE)>
+
+        int  RL_UNSETSTATE(int)                                 # GRL 6.0
+
+=item C<ISSTATE(READLINE_STATE)>
+
+        int  RL_ISSTATE(int)                                    # GRL 6.0
+
 =item C<save_state(READLINE_STATE)>
 
         READLINE_STATE  rl_save_state()                         # GRL 6.0

--- a/Gnu.pm
+++ b/Gnu.pm
@@ -107,6 +107,7 @@ BEGIN {
                   Exporter DynaLoader);
 
     our %EXPORT_TAGS = (
+        readerr =>      [qw(READERR)],
         prompt =>       [qw(RL_PROMPT_START_IGNORE RL_PROMPT_END_IGNORE)],
         match_type =>   [qw(NO_MATCH SINGLE_MATCH MULT_MATCH)],
         keymap_type =>  [qw(ISFUNC ISKMAP ISMACR)],
@@ -128,6 +129,7 @@ BEGIN {
                             RL_STATE_EOF
                             )],
         );
+    Exporter::export_ok_tags('readerr');
     Exporter::export_ok_tags('prompt');
     Exporter::export_ok_tags('match_type');
     Exporter::export_ok_tags('keymap_type');
@@ -173,6 +175,10 @@ our %Features = (
 # readline.h, etc.  But it needs some calling convention change and
 # will cause compatiblity problem. I hope the definition of these
 # constant value will not be changed.
+
+# Input error; can be returned by (*rl_getc_function) if readline is reading
+# a top-level command (RL_ISSTATE (RL_STATE_READCMD)).
+sub READERR      { -2; }
 
 # for non-printing characters in prompt string
 sub RL_PROMPT_START_IGNORE      { "\001"; }
@@ -2154,6 +2160,10 @@ No symbols are exported by default.
 The following tags are defined and their symbols can be exported.
 
 =over 4
+
+=item readerr
+
+READERR
 
 =item prompt
 

--- a/Gnu/XS.pm
+++ b/Gnu/XS.pm
@@ -304,6 +304,24 @@ sub rl_completion_mode {
 }
 
 #
+#       the GNU Readline Macros
+#
+sub SETSTATE {
+    my ($x) = @_;
+    return ($Attribs{readline_state} |= $x);
+}
+
+sub UNSETSTATE {
+    my ($x) = @_;
+    return ($Attribs{readline_state} &= ~$x);
+}
+
+sub ISSTATE {
+    my ($x) = @_;
+    return ($Attribs{readline_state} & $x);
+}
+
+#
 #       for compatibility with Term::ReadLine::Perl
 #
 sub rl_filename_list {

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,29 +1,54 @@
-Changes		A change history
-Gnu.pm		The GNU Readline extension Perl module
-Gnu.xs		The GNU Readline extension external subroutines
+# This file lists the files included in Term::ReadLine::Gnu module distribution
+
+Changes                 A change history
+INSTALL.md              Installtion instructions
+MANIFEST                This list of files
+Makefile.PL             The GNU Readline extension makefile writer
+README.md               The Instructions
+ppport.h                Perl/Pollution/Portability Version 3.68
+typemap                 The GNU Readline extension interface types
+
+# Main Module Files
+Gnu.pm                  The GNU Readline extension Perl module
+Gnu.xs                  The GNU Readline extension external subroutines
 Gnu/XS.pm
-INSTALL.md	Installtion instructions
-MANIFEST	This list of files
-Makefile.PL	The GNU Readline extension makefile writer
-README.md	The Instructions
-eg/perlsh	A powerful calculator
-eg/fileman	A short completion example
-eg/pftp		An ftp client with the GNU Readline support
-eg/ptksh+	Simple perl/Tk shell which demonstrates the callback functions
-ppport.h	Perl/Pollution/Portability Version 1.0007
-t/comptest/0123		A file for t/readline.t
-t/comptest/012345	A file for t/readline.t
-t/comptest/023456	A file for t/readline.t
-t/comptest/README	A file for t/readline.t
-t/comptest/a_b		A file for t/readline.t
-t/00checkver.t	A version check script
-t/01test_use.t	A test for "use Term::ReadLine"
-t/02test_use.t	A test for "use Term::ReadLine"
-t/callback.t	A test script for the GNU Readline callback function
-t/history.t	A test script for the GNU History Library function
-t/inputrc	A file for t/readline.t
-t/readline.t	A test script for the GNU Readline Library function
-t/utf8_binary.t	A test script for UTF-8 binary string
-t/utf8_text.t	A test script for UTF-8 text string
-t/utf8.txt	A file for t/utf8_*.t
-typemap		The GNU Readline extension interface types
+
+# Test Scripts
+t/comptest/0123         A file for t/readline.t
+t/comptest/012345       A file for t/readline.t
+t/comptest/023456       A file for t/readline.t
+t/comptest/README       A file for t/readline.t
+t/comptest/a_b          A file for t/readline.t
+t/00checkver.t          A version check script
+t/01test_use.t          A test for "use Term::ReadLine"
+t/02test_use.t          A test for "use Term::ReadLine"
+t/callback.t            A test script for the GNU Readline callback function
+t/history.t             A test script for the GNU History Library function
+t/inputrc               A file for t/readline.t
+t/readline.t            A test script for the GNU Readline Library function
+t/utf8_binary.t         A test script for UTF-8 binary string
+t/utf8_text.t           A test script for UTF-8 text string
+t/utf8.txt              A file for t/utf8_*.t
+
+# Sample Scripts
+eg/perlsh               A powerful calculator
+eg/pftp                 An ftp client with the GNU Readline support
+eg/ptksh+               Simple perl/Tk shell which demonstrates the callback functions
+
+# The following are ported from the examples in the GNU Readline Library distribution.
+eg/rlversion            Print out readline's version number
+eg/rlbasic              A basic readline() loop example
+eg/manexamp             2.1 Basic Behavior: rl_gets(), 2.4.13 A Readline Example: invert_case_line()
+eg/rltest               readline() loop + add_history() + history_list()
+eg/rl                   readline() loop + ri_startup_hook, rl_insert_text(), rl_instream, rl_num_chars_to_read
+eg/rlevent              rl + rl_event_hook
+eg/rlkeymaps            Tests for keymap functions
+eg/histexamp            history library example program
+eg/rl-callbacktest      2.4.14 Alternate Interface Example
+eg/rl-callbacktest2     Provides readline()-like interface using the alternate interface
+eg/rl-callbacktest3     rl-callbacktest + sigint_handler() + rl_getc_function
+eg/excallback           Alternate interface + rl_set_prompt()
+eg/rlptytest            Another alternate interface example using pty
+eg/rl-timeout           Test various readline builtin timeouts
+eg/rlcat                cat(1) using readline
+eg/fileman              2.6.4 A Short Completion Example: file manager example for readline library

--- a/eg/excallback
+++ b/eg/excallback
@@ -1,0 +1,135 @@
+#!/usr/bin/env perl
+#
+# excallback: Another test harness for the readline callback interface.
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/excallback.c in the GNU Readline Library
+#   Author: Jeff Solomon <jsolomon@stanford.edu>
+
+# This little examples demonstrates the alternate interface to using readline.
+# In the alternate interface, the user maintains control over program flow and
+# only calls readline when STDIN is readable. Using the alternate interface,
+# you can do anything else while still using readline (like talking to a
+# network or another program) without blocking.
+#
+# Specifically, this program highlights two importants features of the
+# alternate interface. The first is the ability to interactively change the
+# prompt, which can't be done using the regular interface since rl_prompt is
+# read-only.
+#
+# The second feature really highlights a subtle point when using the alternate
+# interface. That is, readline will not alter the terminal when inside your
+# callback handler. So let's so, your callback executes a user command that
+# takes a non-trivial amount of time to complete (seconds). While your
+# executing the command, the user continues to type keystrokes and expects them
+# to be re-echoed on the new prompt when it returns. Unfortunately, the default
+# terminal configuration doesn't do this. After the prompt returns, the user
+# must hit one additional keystroke and then will see all of his previous
+# keystrokes. To illustrate this, compile and run this program. Type "sleep" at
+# the prompt and then type "bar" before the prompt returns (you have 3
+# seconds). Notice how "bar" is re-echoed on the prompt after the prompt
+# returns? This is what you expect to happen. Now comment out the 4 lines below
+# the line that says COMMENT LINE BELOW. Recompile and rerun the program and do
+# the same thing. When the prompt returns, you should not see "bar". Now type
+# "f", see how "barf" magically appears? This behavior is un-expected and not
+# desired.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use IO::Pty;
+use POSIX qw(termios_h _POSIX_VDISABLE);
+
+my $t = new Term::ReadLine 'rlptytest';
+my $a = $t->Attribs;
+
+my $prompt = 1;
+my $old_lflag;
+my $old_vtime;
+my $term;
+
+# main program
+
+sub main {
+    # Adjust the terminal slightly before the handler is installed. Disable
+    # canonical mode processing and set the input character time flag to be
+    # non-blocking.
+    $term = POSIX::Termios->new;
+    if (!defined($term->getattr(fileno(STDIN)))) {
+        die "tcgetattr: $!\n";
+    }
+    $old_lflag = $term->getlflag();
+    $old_vtime = $term->getcc(VTIME);
+    $term->setlflag($old_lflag & ~ICANON);
+    $term->setcc(1, VTIME);
+
+    # COMMENT LINE BELOW - see above
+    if (!defined($term->setattr(fileno(STDIN), TCSANOW))) {
+        die "tcsetattr: $!\n";
+    }
+
+    $t->add_defun("change-prompt", \&change_prompt, ord "\cT");
+    $t->callback_handler_install(get_prompt(), \&process_line);
+    while (1) {
+        my $fds = '';
+        vec($fds, fileno(STDIN), 1) = 1;
+        if (select($fds, undef, undef, undef) < 0) {
+            die "select: $!\n";
+        }
+        $t->callback_read_char() if (vec($fds, fileno(STDIN), 1));
+    }
+    exit 0;
+}
+
+sub process_line {
+    my ($line) = @_;
+    if (!$line) {
+        printf STDERR "\n";
+
+        # reset the old terminal setting before exiting
+        $term->setlflag($old_lflag);
+        $term->setcc($old_vtime, VTIME);
+        if (!defined($term->setattr(fileno(STDIN), TCSANOW))) {
+            die "tcsetattr: $!\n";
+        }
+        exit(0);
+    }
+    if ($line eq "sleep") {
+        sleep(3);
+    } else {
+        print STDERR "|$line|\n";
+    }
+}
+sub change_prompt {
+    # toggle the prompt variable
+    $prompt = !$prompt;
+    $t->set_prompt(get_prompt());
+}
+sub change_promptx {
+    # toggle the prompt variable
+    $prompt = !$prompt;
+
+    # save away the current contents of the line
+    my $line_buf = $a->{line_buffer};
+
+    # install a new handler which will change the prompt and erase the current line
+    $t->callback_handler_install(get_prompt(), \&process_line);
+
+    # insert the old text on the new line
+    $t->insert_text($line_buf);
+
+    # redraw the current line - this is an undocumented function. It invokes the
+    # redraw-current-line command.
+    # $t->refresh_line(0, 0);
+    # $t->forced_update_display();
+    # $t->reset_line_state();
+    $t->redisplay();
+}
+
+sub get_prompt {
+    # The prompts can even be different lengths!
+    return $prompt ? "Hit ctrl-t to toggle prompt> " : "Pretty cool huh?> ";
+}
+
+main();

--- a/eg/fileman
+++ b/eg/fileman
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 #
 # This is a sample program of Term::ReadLine::Gnu perl module.  The
 # origin is a C program in the GNU Readline Libarary manual Edition

--- a/eg/histexamp
+++ b/eg/histexamp
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+#
+# histexamp -- history library example program.
+# https://tiswww.case.edu/php/chet/readline/history.html#History-Programming-Example
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/histexamp.c in the GNU Readline Library
+#   Copyright (C) 1987-2009 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use POSIX qw(strftime);
+
+my $t = new Term::ReadLine 'histexamp';
+my $a = $t->Attribs;
+
+my $done = 0;
+$t->using_history();
+$| = 1;    # autoflush
+while (!$done) {
+    printf('history$ ');
+    my $line = <>;
+    $line = 'quit' unless $line;
+    chomp $line;
+
+    if ($line) {
+        my ($result, $expansion) = $t->history_expand($line);
+        print $expansion, "\n" if ($result);
+
+        continue if ($result < 0 || $result == 2);
+
+        $t->add_history($expansion);
+        $line = $expansion;
+    }
+
+    if ($line eq "quit") {
+        $done = 1;
+    } elsif ($line eq "save") {
+        $t->write_history("history_file");
+    } elsif ($line eq "read") {
+        $t->read_history("history_file");
+    } elsif ($line eq "list") {
+        my $i = 0;
+        for (my $i = 0; $i < $a->{history_length}; $i++) {
+            my $offset  = $i + $a->{history_base};
+            my $tt      = $t->history_get_time($offset);
+            my $timestr = strftime("%a %R", localtime($tt));
+            printf("%d: %s: %s\n", $offset, $timestr, $t->history_get($offset));
+        }
+    } elsif ($line =~ /^delete/) {
+        my $which;
+        if (($which) = $line =~ /^delete\s+(\d+)$/) {
+            my $entry = $t->remove_history($which - $a->{history_base});
+            if (!$entry) {
+                warn("No such entry $which\n");
+            }
+        } else {
+            warn("non-numeric arg given to `delete'\n");
+        }
+    }
+}
+exit 0;

--- a/eg/manexamp
+++ b/eg/manexamp
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+#
+# manexamp -- The examples which appear in the documentation are here.
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/manexamp.c in the GNU Readline Library
+#   Copyright (C) 1987-2023 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'manexamp';
+my $a = $t->Attribs;
+
+# ****************************************************************
+#
+#   			How to Emulate gets ()
+#
+# ****************************************************************
+# https://tiswww.case.edu/php/chet/readline/readline.html#Basic-Behavior
+
+# Read a string, and return it.  Returns undef on EOF.
+sub rl_gets () {
+    return $t->readline('');
+}
+
+# ****************************************************************
+#
+#        Writing a Function to be Called by Readline.
+#
+# ****************************************************************
+# https://tiswww.case.edu/php/chet/readline/readline.html#A-Readline-Example
+
+# Invert the case of the COUNT following characters.
+sub invert_case_line {
+    my ($count, $key) = @_;
+
+    my $start = $a->{point};
+
+    # Find the end of the range to modify.
+    my $end = $start + $count;
+
+    # Force it to be within range.
+    if ($end > $a->{end}) {
+        $end = $a->{end};
+    } elsif ($end < 0) {
+        $end = -1;
+    }
+
+    return 0 if $start == $end;
+
+    if ($start > $end) {
+        my $temp = $start;
+        $start = $end + 1;
+        $end   = $temp + 1;
+    }
+
+    # Tell readline that we are modifying the line, so it will save
+    # undo information.
+    $t->modifying($start, $end);
+
+    # I'm happy with Perl :-)
+    substr($a->{line_buffer}, $start, $end - $start) =~ tr/A-Za-z/a-zA-Z/;
+
+    # Move point to on top of the last character changed.
+    $a->{point} = $count < 0 ? $start : $end - 1;
+    return 0;
+}
+
+$t->initialize();
+$t->add_defun('invert-case-line', \&invert_case_line);
+$t->bind_key(ord 'c', 'invert-case-line', 'emacs-meta');
+while (defined($_ = rl_gets())) {
+    invert_case_line(1, '');
+    print "$_\n";
+}
+exit 0;

--- a/eg/perlsh
+++ b/eg/perlsh
@@ -1,4 +1,4 @@
-#! /usr/local/bin/perl
+#!/usr/bin/env perl
 #
 #
 #       Copyright (c) 1996 Hiroo Hayashi. All Rights Reserved.

--- a/eg/pftp
+++ b/eg/pftp
@@ -1,4 +1,4 @@
-#! /usr/local/bin/perl
+#!/usr/bin/env perl
 #
 #       Copyright (c) 1997 Hiroo Hayashi.  All Rights Reserved.
 #

--- a/eg/ptksh+
+++ b/eg/ptksh+
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/env perl -w
 #
 # POD documentation after __END__
 

--- a/eg/rl
+++ b/eg/rl
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+#
+# rl - command-line interface to read a line from the standard input
+#      (or another fd) using readline.
+#
+# usage: rl [-p prompt] [-u unit] [-d default] [-n nchars] [-e]
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl.c and examples/rlevent.c in the GNU Readline Library
+#   Copyright (C) 1987-2023 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use File::Basename;
+use Getopt::Std;
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
+my $VERSION = "1.0";
+
+# default values
+my $prompt  = 'readline$ ';
+my $fd      = 0;
+my $deftext = "";
+my $nch     = 0;
+
+my $t = new Term::ReadLine 'rl';
+my $a = $t->Attribs;
+
+sub event_hook {
+    print STDERR "ding!\n";
+    sleep(1);
+    return 0;
+}
+
+sub set_deftext {
+    if ($deftext) {
+        $t->insert_text($deftext);
+        $deftext = "";
+        $a->{startup_hook} = undef;
+    }
+    return 0;
+}
+
+my $progname = basename($0);
+
+sub HELP_MESSAGE {
+    my ($fh) = @_;
+    print $fh <<EOM;
+usage: $progname  [-p prompt] [-u unit] [-d default] [-n nchars] [-e]
+  -p prompt:    specify the prompt string
+  -u unit:      specify the file descriptor to read from
+  -d default:   specify the default text
+  -n nchars:    specify the number of characters to read
+  -e:           enable event hook
+EOM
+
+}
+
+sub VERSION_MESSAGE {
+    my ($fh) = @_;
+    print $fh "version: $VERSION\n";
+}
+
+our ($opt_p, $opt_u, $opt_d, $opt_n, $opt_e);
+getopts('p:u:d:n:e');
+
+$prompt  = $opt_p if defined($opt_p);
+$fd      = $opt_u if defined($opt_u);
+$deftext = $opt_d if defined($opt_d);
+$nch     = $opt_n if defined($opt_n);
+
+die "bad file descriptor $fd\n" if $fd < 0;
+die "bad value for -n: $nch\n"  if $nch < 0;
+
+if ($fd != 0) {
+    stat($fd)                 or die "$fd: $!\n";
+    open(my $ifp, "<&=", $fd) or die "$fd: $!\n";
+    $a->{instream} = $ifp;
+}
+
+$a->{startup_hook}      = \&set_deftext if ($deftext && $deftext ne "");
+$a->{num_chars_to_read} = $nch          if $nch > 0;
+$a->{event_hook}        = \&event_hook  if $opt_e;
+
+my $temp = $t->readline($prompt) or exit(1);
+print "$temp\n";
+
+exit(0);

--- a/eg/rl-callbacktest
+++ b/eg/rl-callbacktest
@@ -1,0 +1,111 @@
+#!/usr/bin/env perl
+#
+# rl-callbacktest
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl-callbacktest.c and examples/rl-callbacktest3.c
+#   in the GNU Readline Library
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'rl-callbacktest';
+my $a = $t->Attribs;
+
+my $sigwinch_received = 0;
+my $sigint_received   = 0;
+my $running           = 0;
+my $prompt            = 'rltest$ ';
+
+# Handle SIGWINCH and window size changes when readline is not active and
+# reading a character.
+sub sigwinch_handler {
+    my $sig = shift;
+    $sigwinch_received = 1;
+}
+
+# Handle SIGINT when readline is not active and reading a character.
+sub sigint_handler {
+    my $sig = shift;
+    $sigint_received = 1;
+}
+
+# Callback function called for each line when accept-line executed, EOF
+# seen, or EOF character read.  This sets a flag and returns; it could
+# also call exit(3).
+sub cb_linehandler {
+    my $line = shift;
+
+    # Can use ^D (stty eof) or `exit' to exit.
+    if (!$line || $line eq "exit") {
+        print "\n" unless $line;
+        print "exit\n";
+
+        # This function needs to be called to reset the terminal settings,
+        # and calling it from the line handler keeps one extra prompt from
+        # being displayed.
+        $t->callback_handler_remove();
+
+        $running = 0;
+    } else {
+        $t->add_history($line) if $line;
+        print "input line: $line\n";
+    }
+}
+
+# replace with something more complex if desired
+sub my_getc {
+    my $stream = shift;
+    my $ch     = $t->getc($stream);
+    return $ch;
+}
+
+# Handle SIGWINCH
+$SIG{WINCH} = \&sigwinch_handler;
+
+# Handle SIGINT
+$SIG{INT} = \&sigint_handler;
+
+# Install the line handler.
+$t->callback_handler_install($prompt, \&cb_linehandler);
+
+# Enter a simple event loop.  This waits until something is available
+# to read on readline's input stream (defaults to standard input) and
+# calls the builtin character read callback to read it.  It does not
+# have to modify the user's terminal settings.
+$running = 1;
+while ($running) {
+    my $fds = '';
+    vec($fds, fileno($a->{instream}), 1) = 1;
+
+    my $r = select($fds, undef, undef, undef);
+    if ($r < 0 && $! && !$!{EINTR}) {   # EINTR is not an error
+        warn "$0: select: $!\n";
+        $t->callback_handler_remove();
+        last;
+    }
+    if ($sigwinch_received) {
+        warn "$0: SIGWINCH received\n";
+        $t->resize_terminal();
+        $sigwinch_received = 0;
+    }
+    if ($sigint_received) {
+        print "Quit\n";
+
+        $t->callback_handler_remove();
+        $t->callback_handler_install($prompt, \&cb_linehandler);
+
+        $sigint_received = 0;
+        next;
+    }
+    next if $r < 0; # select returns EINTR (interrupted system call)
+
+    if (vec($fds, fileno($a->{instream}), 1)) {
+        $t->callback_read_char();
+    }
+}
+
+print "$0: Event loop has exited\n";
+exit 0;

--- a/eg/rl-callbacktest2
+++ b/eg/rl-callbacktest2
@@ -1,0 +1,123 @@
+#!/usr/bin/env perl
+#
+# rl-callbacktest2
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl-callbacktest2.c in the GNU Readline Library
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+BEGIN {
+    import Term::ReadLine::Gnu qw(RL_STATE_ISEARCH RL_STATE_NSEARCH);
+}
+
+my $t = new Term::ReadLine 'rl-callbacktest2';
+my $a = $t->Attribs;
+
+my $saw_signal = 0;
+
+my $running = 0;
+my $prompt  = 'rltest$ ';
+my $input_string;
+
+# Callback function called for each line when accept-line executed, EOF
+# seen, or EOF character read.  This sets a flag and returns; it could
+# also call exit(3).
+sub cb_linehandler {
+    my $line = shift;
+    $t->add_history($line) if $line;
+    print "input line: ", ($line or ""), "\n";
+    $input_string = $line;
+    $t->callback_handler_remove();
+}
+
+sub cb_readline {
+    my $not_done = "";
+
+    # Install the line handler.
+    $t->callback_handler_install($prompt, \&cb_linehandler);
+
+    # printf STDERR ("readline_state = 0x%lx\n", $a->{readline_state});
+    if ($t->ISSTATE(RL_STATE_ISEARCH)) {
+        printf STDERR (
+            "cb_readline: after handler install, state (ISEARCH) = %lx\n",
+            $a->{readline_state}
+        );
+    } elsif ($t->ISSTATE(RL_STATE_NSEARCH)) {
+        printf STDERR (
+            "cb_readline: after handler install, state (NSEARCH) = %lx\n",
+            $a->{readline_state}
+        );
+    }
+
+    # MULTIKEY VIMOTION NUMERICARG _rl_callback_func
+
+    my $fds = '';
+    vec($fds, fileno($a->{instream}), 1) = 1;
+
+    $input_string = $not_done;
+
+    while (defined($input_string) and $input_string eq $not_done) {
+        my $r   = 0;
+        my $err = 0;
+
+        # Enter a simple event loop. This waits until something is available
+        # to read on readline's input stream (defaults to standard input) and
+        # calls the builtin character read callback to read it. It does not
+        # have to modify the user's terminal settings.
+        while ($r == 0) {
+            vec($fds, fileno($a->{instream}), 1) = 1;
+            $r   = select($fds, undef, undef, 0.1);
+            $err = $!;
+        }
+
+        if ($saw_signal) {
+            sigint_handler($saw_signal);
+        }
+
+        if ($r < 0) {
+            warn "rltest: select: $!\n";
+            $t->callback_handler_remove();
+            last;
+        }
+
+        if ($r > 0) {
+            $t->callback_read_char();
+        }
+    }
+    return $input_string;
+}
+
+sub sigint_sighandler {
+    $saw_signal = shift;
+}
+
+sub sigint_handler {
+    my $s = shift;
+    $t->free_line_state();
+    $t->callback_sigcleanup();
+    $t->cleanup_after_signal();
+    $t->callback_handler_remove();
+    $saw_signal = 0;
+    printf STDERR ("sigint_handler: readline state = 0x%lx\n",
+        $a->{readline_state});
+    return $s;
+}
+
+$running = 1;
+$a->{catch_signals} = 1;
+
+$t->bind_key(ord 'r', 'history-search-backward', 'emacs-meta');
+$t->bind_key(ord 's', 'history-search-forward',  'emacs-meta');
+
+$SIG{INT} = \&sigint_sighandler;
+while ($running) {
+    my $p = cb_readline();
+    last if (!$p or $p eq 'exit');
+}
+
+print "$0: Event loop has exited\n";
+exit 0;

--- a/eg/rl-timeout
+++ b/eg/rl-timeout
@@ -1,0 +1,198 @@
+#!/usr/bin/env perl
+#
+# rl-timeout
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl-timeout.c in the GNU Readline Library
+#   Copyright (C) 2021 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+BEGIN {
+    import Term::ReadLine::Gnu qw(RL_STATE_TIMEOUT READERR);
+}
+
+sub usage {
+    print <<EOM;
+usage: rl-timeout [readline1 | readline2 | callback1 | callback2] [timeout]
+EOM
+}
+
+my $t = new Term::ReadLine 'rl-timeout';
+my $a = $t->Attribs;
+
+if ($a->{readline_version} < 0x0802) {
+    warn "rl-timeout: This example requires readline 8.2 or later.\n";
+    exit(1);
+}
+my $timeout_secs  = 1;
+my $timeout_usecs = 0;
+my $running       = 0;
+my $prompt        = 'rl-timeout$ ';
+my $UINT_MAX      = ~0;
+
+# ****************************************************************
+#
+# Example 1: readline () with rl_readline_state
+#
+# ****************************************************************
+
+sub rltest_timeout_readline1 {
+    $t->set_timeout($timeout_secs, $timeout_usecs);
+    my $temp = $t->readline($prompt);
+    if ($t->ISSTATE(RL_STATE_TIMEOUT)) {
+        print "timeout\n";
+    } elsif (!$temp) {
+        print "no input line\n";
+    } else {
+        print "input line: $temp\n";
+    }
+}
+
+# ****************************************************************
+#
+# Example 2: readline () with rl_timeout_event_hook
+#
+# ****************************************************************
+
+sub timeout_handler {
+    print "timeout\n";
+    return READERR;
+}
+
+sub rltest_timeout_readline2 {
+    my $temp;
+
+    $t->set_timeout($timeout_secs, $timeout_usecs);
+    $a->{timeout_event_hook} = \&timeout_handler;
+    $temp = $t->readline($prompt);
+    if (!$temp) {
+        print "no input line\n";
+    } else {
+        print "input line: $temp\n";
+    }
+}
+
+# ****************************************************************
+#
+# Example 3: rl_callback_* () with rl_timeout_remaining
+#
+# ****************************************************************
+
+# Callback function called for each line when accept-line executed, EOF
+# seen, or EOF character read.  This sets a flag and returns; it could
+# also call exit(3).
+sub cb_linehandler {
+    my ($line) = @_;
+
+    if (!$line || $line eq "exit") {
+        if (!$line) {
+            print "\n";
+        }
+        print "exit\n";
+
+        # This function needs to be called to reset the terminal settings,
+        # and calling it from the line handler keeps one extra prompt from
+        # being displayed.
+        $t->callback_handler_remove();
+        $running = 0;
+    } else {
+        if ($line ne "") {
+            $t->add_history($line);
+        }
+        print "input line: $line\n";
+    }
+}
+
+sub rltest_timeout_callback1 {
+    $t->set_timeout($timeout_secs, $timeout_usecs);
+    $t->callback_handler_install($prompt, \&cb_linehandler);
+    $running = 1;
+    while ($running) {
+        my $fds = '';
+        vec($fds, fileno($a->{instream}), 1) = 1;
+        # -1: error, 0: timeout, 1: input available (the timeout has not expired)
+        my ($r, $sec, $usec) = $t->timeout_remaining();
+        if ($r == 1) {
+            my $timeout = $sec + $usec / 1000000;
+            $r = select($fds, undef, undef, $timeout);
+        } elsif ($r < 0) {
+            die "Error in rl_timout_remaining().\n";
+        }
+        if ($r < 0 && $! && !$!{EINTR}) {
+            warn "rl-timeout: select: $!";
+            $t->callback_handler_remove();
+            last;
+        } elsif ($r == 0) { # timeout in rl_timeout_remaining() or select()
+            print "rl-timeout: timeout\n";
+            $t->callback_handler_remove();
+            last;
+        }
+
+        # FD_ISSET(fileno($a->{instream}), $fds)
+        if (vec($fds, fileno($a->{instream}), 1)) {
+            $t->callback_read_char();
+        }
+    }
+
+    print "rl-timeout: Event loop has exited\n";
+}
+
+# ****************************************************************
+#
+# Example 4: rl_callback_* () with rl_timeout_event_hook
+#
+# ****************************************************************
+
+sub cb_timeouthandler {
+    print "timeout\n";
+    $t->callback_handler_remove();
+    $running = 0;
+    return READERR;
+}
+
+sub rltest_timeout_callback2 {
+    $t->set_timeout($timeout_secs, $timeout_usecs);
+    $a->{timeout_event_hook} = \&cb_timeouthandler;
+    $t->callback_handler_install($prompt, \&cb_linehandler);
+    $running = 1;
+    while ($running) {
+        $t->callback_read_char();
+    }
+
+    print "rl-timeout: Event loop has exited\n";
+}
+
+if ($#ARGV >= 0) {
+    if ($#ARGV >= 1) {
+        my $timeout = $ARGV[1];
+        if ($timeout <= 0.0) {
+            warn "rl-timeout: specify a positive number for timeout.\n";
+            exit(2);
+        } elsif ($timeout > $UINT_MAX) {
+            warn "rl-timeout: timeout too large.\n";
+            exit(2);
+        }
+        $timeout_secs  = int $timeout;
+        $timeout_usecs = int(($timeout - $timeout_secs) * 1000000 + 0.5);
+    }
+    if ($ARGV[0] eq "readline1") {
+        rltest_timeout_readline1();
+    } elsif ($ARGV[0] eq "readline2") {
+        rltest_timeout_readline2();
+    } elsif ($ARGV[0] eq "callback1") {
+        rltest_timeout_callback1();
+    } elsif ($ARGV[0] eq "callback2") {
+        rltest_timeout_callback2();
+    } else {
+        usage();
+        exit(2);
+    }
+} else {
+    usage();
+    exit(2);
+}
+exit(0);

--- a/eg/rlbasic
+++ b/eg/rlbasic
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+#
+# rlbasic
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rlbasic.c in the GNU Readline Library
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'rlbasic';
+
+while (1) {
+    my $input = $t->readline('');
+    last unless defined $input;
+    print("$input\n");
+    if ($input eq 'exit') {
+        last;
+    }
+}
+exit 0;

--- a/eg/rlcat
+++ b/eg/rlcat
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+#
+# rlcat - cat(1) using readline
+#
+# usage: rlcat [-vEVN] [filename]
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl.c in the GNU Readline Library
+#   Copyright (C) 1987-2023 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use File::Basename;
+use Getopt::Std;
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
+my $VERSION = "1.0";
+
+my $t = new Term::ReadLine 'rl';
+my $a = $t->Attribs;
+
+my $progname = basename($0);
+
+sub HELP_MESSAGE {
+    my ($fh) = @_;
+    print $fh <<EOM;
+usage: $progname [-vEVN] [filename]
+  -v: untraslate control characters (not implemented yet)
+  -E: emacs mode (default)
+  -V: vi mode
+  -N: No readline
+EOM
+}
+
+sub VERSION_MESSAGE {
+    my ($fh) = @_;
+    print $fh "version: $VERSION\n";
+}
+
+our ($opt_v, $opt_E, $opt_V, $opt_N);
+getopts('vEVN');
+
+if (!-t STDIN or @ARGV or $opt_N) {
+    system "cat @ARGV";
+    exit $?;
+}
+
+$t->variable_bind("editing-mode", $opt_V ? "vi" : "emacs");
+while (my $temp = $t->readline("")) {
+    print "$temp\n";
+}
+exit 0;    # perl does not support ferror()
+
+# rl_untranslate_keyseq() is not documented but used in rlcat.c.

--- a/eg/rlevent
+++ b/eg/rlevent
@@ -1,0 +1,91 @@
+#!/usr/bin/env perl
+#
+# rl - command-line interface to read a line from the standard input
+#      (or another fd) using readline.
+#
+# usage: rl [-p prompt] [-u unit] [-d default] [-n nchars]
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rl.c in the GNU Readline Library
+#   Copyright (C) 1987-2023 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use File::Basename;
+use Getopt::Std;
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
+my $VERSION = "1.0";
+
+# default values
+my $prompt  = 'readline$ ';
+my $fd      = 0;
+my $deftext = "";
+my $nch     = 0;
+
+my $t = new Term::ReadLine 'rl';
+my $a = $t->Attribs;
+
+sub event_hook {
+    print STDERR "ding!\n";
+    sleep(1);
+    return 0;
+}
+
+sub set_deftext {
+    if ($deftext) {
+        $t->insert_text($deftext);
+        $deftext = "";
+        $a->{startup_hook} = undef;
+    }
+    return 0;
+}
+
+my $progname = basename($0);
+
+sub HELP_MESSAGE {
+    my ($fh) = @_;
+    print $fh <<EOM;
+"usage: $progname [-p prompt] [-u unit] [-d default] [-n nchars]
+EOM
+}
+
+sub VERSION_MESSAGE {
+    my ($fh) = @_;
+    print $fh "version: $VERSION\n";
+}
+
+our ($opt_p, $opt_u, $opt_d, $opt_n);
+getopts('p:u:d:n:');
+
+$prompt  = $opt_p if defined($opt_p);
+$fd      = $opt_u if defined($opt_u);
+$deftext = $opt_d if defined($opt_d);
+$nch     = $opt_n if defined($opt_n);
+
+if ($fd < 0) {
+    die "bad file descriptor $fd\n";
+}
+if ($nch < 0) {
+    die "bad value for -n: $nch\n";
+}
+if ($fd != 0) {
+    stat($fd)                 or die "$fd: $!\n";
+    open(my $ifp, "<&=", $fd) or die "$fd: $!\n";
+    $a->{instream} = $ifp;
+}
+
+if ($deftext && $deftext ne "") {
+    $a->{startup_hook} = \&set_deftext;
+}
+
+if ($nch > 0) {
+    $a->{num_chars_to_read} = $nch;
+}
+
+$a->{event_hook} = \&event_hook;
+my $temp = $t->readline($prompt) or exit(1);
+print "$temp\n";
+
+exit(0);

--- a/eg/rlkeymaps
+++ b/eg/rlkeymaps
@@ -1,0 +1,54 @@
+#!/usr/bin/env perl
+#
+# rlkeymaps
+#
+#   Copyright(C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rlkeymaps.c in the GNU Readline Library
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'rlkeymaps';
+
+my $errs = 0;
+my $r;
+
+my $nmap = $t->make_keymap();
+
+$r = $t->set_keymap_name("emacs", $nmap);
+if ($r >= 0) {
+    warn("rlkeymaps: error: able to rename `emacs' keymap\n");
+    $errs++;
+}
+
+my $emacsmap = $t->get_keymap_by_name("emacs");
+$r = $t->set_keymap_name("newemacs", $emacsmap);
+if ($r >= 0) {
+    warn("rlkeymaps: error: able to set new name for emacs keymap\n");
+    $errs++;
+}
+
+$r = $t->set_keymap_name("newemacs", $nmap);
+if ($r < 0) {
+    warn("rlkeymaps: error: newemacs: could not set keymap name\n");
+    $errs++;
+}
+
+my $newemacs = $t->copy_keymap($emacsmap);
+$r = $t->set_keymap_name("newemacs", $newemacs);
+if ($r < 0) {
+    warn <<EOM;
+rlkeymaps: error: newemacs: could not set `newemacs' keymap to new map
+EOM
+    $errs++;
+}
+
+$r = $t->set_keymap_name("emacscopy", $newemacs);
+if ($r < 0) {
+    warn("rlkeymaps: error: emacscopy: could not rename created keymap\n");
+    $errs++;
+}
+
+exit $errs;

--- a/eg/rlptytest
+++ b/eg/rlptytest
@@ -1,0 +1,249 @@
+#!/usr/bin/env perl
+#
+# rlptytest: Another test harness for the readline callback interface.
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rlptytest.c in the GNU Readline Library
+#   Author: Bob Rossi <bob@brasko.net>
+
+use strict;
+use warnings;
+use Term::ReadLine;
+use IO::Pty;
+use POSIX qw(termios_h _POSIX_VDISABLE);
+
+# sys/ioctl.ph may not exist on some systems.
+#   cf. https://perldoc.perl.org/functions/ioctl
+# require 'sys/ioctl.ph';   # for TIOCGWINSZ
+
+my $debug = 1;
+my $t = new Term::ReadLine 'rlptytest';
+my $a = $t->Attribs;
+
+# Master/Slave PTY used to keep readline off of stdin/stdout.
+my $masterfh;
+my $slavefh;
+
+sub quit {
+    tty_reset(fileno(STDIN));
+    close($masterfh);
+    close($slavefh);
+    print "\n";
+    exit(0);
+}
+
+sub sigint {
+    quit();
+}
+
+sub sigwinch {
+    $t->resize_terminal();
+}
+
+# STDIN  -> user_input()     -> masterfh -> pty -> slavefh -> rl_instream -> callback_read_char()
+# STDERR <- readline_input() <- masterfh <- pty <- slavefh <- rl_outstream
+
+sub user_input {
+    my $buf;
+    my $MAX  = 1024;
+    my $size = sysread(STDIN, $buf, $MAX);
+    die "read: $!\n" unless defined $size;
+
+    my $ret = syswrite($masterfh, $buf, $size);
+    die "print: $!\n" unless $ret;
+}
+
+sub readline_input {
+    my $buf;
+    my $MAX  = 1024;
+    my $size = sysread($masterfh, $buf, $MAX);
+    die "read: $!\n" unless defined $size;
+
+    # Display output from readline
+    print STDERR $buf if ($size > 0);
+}
+
+sub rlctx_send_user_command {
+    my ($line) = @_;
+
+    # This happens when rl_callback_read_char gets EOF
+    return if (!$line);
+    quit() if ($line eq "exit");
+
+    # Don't add the enter command
+    if ($line && $line ne "") {
+        $t->add_history($line);
+    }
+}
+
+sub custom_deprep_term_function {
+}
+
+sub init_readline {
+    my ($inputfh, $outputfh) = @_;
+    $a->{instream}  = $inputfh;
+    $a->{outstream} = $outputfh;
+
+    # Tell readline what the prompt is if it needs to put it back
+    $t->callback_handler_install("(rltest):  ", \&rlctx_send_user_command);
+
+    # Set the terminal type to dumb so the output of readline can be
+    # understood by tgdb
+    $t->reset_terminal("dumb");    # always returns 0
+
+    # For some reason, readline can not deprep the terminal.
+    # However, it doesn't matter because no other application is working on
+    # the terminal besides readline
+    $a->{deprep_term_function} = \&custom_deprep_term_function;
+
+    $t->using_history();
+    $t->read_history(".history");
+}
+
+sub main_loop {
+    while (1) {
+        # Reset the fd_set, and watch for input from GDB or stdin
+        my $rset = '';
+
+        vec($rset, fileno(STDIN),     1) = 1;
+        vec($rset, fileno($slavefh),  1) = 1;
+        vec($rset, fileno($masterfh), 1) = 1;
+
+        # Wait for input
+        if (select($rset, undef, undef, undef) == -1) {
+            if ($! && $!{EINTR}) {
+                next;
+            } else {
+                die "select: $!\n";
+            }
+        }
+
+        # Input received through the pty:  Handle it
+        # Wrote to masterfd, slave fd has that input, alert readline to read it.
+        $t->callback_read_char() if (vec($rset, fileno($slavefh),  1));
+
+        # Input received through the pty.
+        # Readline read from slavefd, and it wrote to the masterfd.
+        readline_input()         if (vec($rset, fileno($masterfh), 1));
+
+        # Input received:  Handle it, write to masterfd (input to readline)
+        user_input()             if (vec($rset, fileno(STDIN),     1));
+    }
+}
+
+# The terminal attributes before calling tty_cbreak
+my $save_termios;
+my ($RESET, $TCBREAK) = (0, 1);
+my $ttystate = $RESET;
+
+# tty_cbreak: Sets terminal to cbreak mode. Also known as noncanonical mode.
+#    1. Signal handling is still turned on, so the user can still type those.
+#    2. echo is off
+#    3. Read in one char at a time.
+#
+# $fh    - The file handle of the terminal
+sub tty_cbreak {
+    my ($fh) = @_;
+    my $fd = fileno($fh);
+
+    $save_termios = POSIX::Termios->new;
+    if (!defined($save_termios->getattr($fd))) {
+        die "tcgetattr: $!\n";
+    }
+    my $buf = POSIX::Termios->new;
+    if (!defined($buf->getattr($fd))) {
+        die "tcgetattr: $!\n";
+    }
+
+    $buf->setlflag($buf->getlflag() & ~(ECHO | ICANON));
+    $buf->setiflag($buf->getiflag() & ~(ICRNL | INLCR));
+    $buf->setcc(1, VMIN);
+    $buf->setcc(0, VTIME);
+
+    $buf->setcc(_POSIX_VDISABLE, &POSIX::VLNEXT)
+      if defined(&POSIX::VLNEXT) && defined(_POSIX_VDISABLE);
+
+    $buf->setcc(_POSIX_VDISABLE, &POSIX::VDSUSP)
+      if defined(&POSIX::VDSUSP) && defined(_POSIX_VDISABLE);
+
+    # enable flow control; only stty start char can restart output
+    # $buf->setiflag($buf->getiflag() | IXON | IXOFF);
+    # $buf->setiflag($buf->getiflag() & ~&POSIX::IXANY) if defined(&POSIX::IXANY);
+
+    # disable flow control; let ^S and ^Q through to pty
+    $buf->setiflag($buf->getiflag() & ~(IXON | IXOFF));
+    $buf->setiflag($buf->getiflag() & ~&POSIX::IXANY) if defined(&POSIX::IXANY);
+
+    if (!defined($buf->setattr($fd, TCSAFLUSH))) {
+        die "tcsetattr: $!\n";
+    }
+
+    $ttystate = $TCBREAK;
+
+    # set size
+
+    # my $winsize = '';
+    # if (!defined(ioctl($fh, TIOCGWINSZ(), $winsize))) {
+    #     die "ioctl: $!\n";
+    # } else {
+    #     my ($rows, $cols, $xpix, $ypix) = unpack 'S4', $winsize;
+    #     warn "$rows rows and $cols cols\n" if $debug;
+    # }
+
+    # use IO::Pty->get_winsize() instead of ioctl() for better portability
+    if ($slavefh->clone_winsize_from(\*STDIN)) {
+        my ($rows, $cols, $xpix, $ypix) = $slavefh->get_winsize();
+        warn "$rows rows and $cols cols\n" if $debug;
+    }
+}
+
+sub tty_off_xon_xoff {
+    my ($fh) = @_;
+    my $fd = fileno($fh);
+
+    my $buf = POSIX::Termios->new;
+    if (!defined($buf->getattr($fd))) {
+        die "tcgetattr: $!\n";
+    }
+
+    $buf->setiflag($buf->getiflag() & ~(IXON | IXOFF));
+
+    if (!defined($buf->setattr($fd, TCSAFLUSH))) {
+        die "tcsetattr: $!\n";
+    }
+}
+
+# tty_reset: Sets the terminal attributes back to their previous state.
+# PRE: tty_cbreak must have already been called.
+#
+# fd    - The file descrioptor of the terminal to reset.
+sub tty_reset {
+    my ($fd) = @_;
+    return if ($ttystate != $TCBREAK);
+
+    if (!defined($save_termios->setattr($fd, TCSAFLUSH))) {
+        die "tcsetattr: $!\n";
+    }
+    $ttystate = $RESET;
+}
+
+#
+# main
+#
+$masterfh = new IO::Pty;
+$slavefh  = $masterfh->slave;
+
+tty_off_xon_xoff($masterfh);
+
+$SIG{INT}   = \&sigint;
+$SIG{WINCH} = \&sigwinch;
+
+init_readline($slavefh, $slavefh);
+tty_cbreak(\*STDIN);
+
+main_loop();
+
+tty_reset(fileno(STDIN));
+
+exit 0;

--- a/eg/rltest
+++ b/eg/rltest
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+#
+# rltest
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rltest.c in the GNU Readline Library
+#   Copyright (C) 1987-2009,2023 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'rltest';
+
+my $prompt = 'readline$ ';
+my $done   = 0;
+while (!$done) {
+    # use full qualified name not to call addhistory() implicitly.
+    my $temp = Term::ReadLine::Gnu::XS::rl_readline($prompt);
+    exit 1 unless defined $temp;
+
+    if ($temp) {
+        print STDERR "$temp\n";
+        $t->addhistory($temp);
+    }
+    $done = 1 if $temp eq 'quit';
+
+    if ($temp eq 'list') {
+        my @list = $t->history_list();
+        foreach my $i (@list) {
+            print STDERR "$i\n";
+        }
+    }
+}
+exit 0;

--- a/eg/rlversion
+++ b/eg/rlversion
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+#
+# rlversion -- print out readline's version number
+#
+#   Copyright (C) 2024 Hiroo Hayashi
+#
+# Derived from: examples/rlversion.c in the GNU Readline Library
+#   Copyright (C) 1987-2009 Free Software Foundation, Inc.
+
+use strict;
+use warnings;
+use Term::ReadLine;
+
+my $t = new Term::ReadLine 'rlversion';
+my $a = $t->Attribs;
+
+print(($a->{library_version} or 'unknown'), "\n");
+exit 0;


### PR DESCRIPTION
also includes

- add macro functions for `rl_readline_state`
- export `READERR`
- use `/usr/bin/env` for sh-bang