### PR TITLE
Fix for compilation in C23 mode

### DIFF
--- a/Gnu.xs
+++ b/Gnu.xs
@@ -613,7 +613,7 @@ enum { STARTUP_HOOK, EVENT_HOOK, GETC_FN, REDISPLAY_FN,
        SIG_EVT, INP_AVL, FN_STAT, TIMEOUT_EVENT,
 };
 
-typedef int XFunction ();
+typedef int XFunction (void);
 static struct fn_vars {
   XFunction **rlfuncp;          /* GNU Readline Library variable */
   XFunction *defaultfn;         /* default function */
@@ -622,7 +622,12 @@ static struct fn_vars {
 } fn_tbl[] = {
   { &rl_startup_hook,   NULL,   startup_hook_wrapper,   NULL }, /* 0 */
   { &rl_event_hook,     NULL,   event_hook_wrapper,     NULL }, /* 1 */
-  { &rl_getc_function,  rl_getc, getc_function_wrapper, NULL }, /* 2 */
+  {
+    (XFunction **)&rl_getc_function,                            /* 2 */
+    (XFunction *)rl_getc,
+    (XFunction *)getc_function_wrapper,
+    NULL
+  },
   {
     (XFunction **)&rl_redisplay_function,                       /* 3 */
     (XFunction *)rl_redisplay,


### PR DESCRIPTION
This (-std=c23) is the default for gcc 15.

Function pointer casts added as per many existing entries in the same table.